### PR TITLE
Corrections to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The following rule governs documentation contributions:
 
 ## Pull Request Checklist
 
-* Branch from the master branch and, if needed, rebase to the current master branch before submitting your pull request. If it doesn't merge cleanly with master you may be asked to rebase your changes.
+* Branch from the main branch and, if needed, rebase to the current main branch before submitting your pull request. If it doesn't merge cleanly with main you may be asked to rebase your changes.
 
 * Commits should be as small as possible while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).
 
@@ -69,7 +69,3 @@ The following rule governs documentation contributions:
 * We use GitHub issues to track bugs and enhancement requests.
 
 * Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee. Therefore, contributors may use but aren't restricted to the issue template provided by the project maintainers.
-
-* When creating an issue, try using one of our issue templates which already contain some guidelines on which content is expected to process the issue most efficiently. If no template applies, you can of course also create an issue from scratch.
-
-* Please apply one or more applicable [labels](https://github.com/corona-warn-app/cwa-documentation/labels) to your issue so that all community members are able to cluster the issues better.


### PR DESCRIPTION
The PR makes various corrections to the document [CONTRIBUTING.md](https://github.com/corona-warn-app/cwa-map-public-frontend/blob/main/CONTRIBUTING.md).

1. The document refers to the branch `master`, however this repository only has one branch and it is named `main` in line with current naming conventions on GitHub. The default branch name in the document is changed to `main`.
2. The document refers to different issue templates. There are no issue templates in this repository. If there were, then they would be in a `.github/ISSUE_TEMPLATE` directory, which doesn't exist on this repository. The corresponding paragraph is removed.
3. The document suggests applying labels. This requires at least triage access to a repository, which is something community members will not generally possess. See [GitHub help - Applying a label](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label). This paragraph is removed.


