### PR TITLE
Remove everything reg. becoming a RAT partner

### DIFF
--- a/static/datenschutz.html
+++ b/static/datenschutz.html
@@ -143,8 +143,6 @@
     <a class="text-light" href="/impressum.html">Impressum</a>
     <a class="text-light" href="/datenschutz.html">Datenschutzerklärung</a>
     <a class="text-light" href="/usage.html">Hilfe</a>
-    <a class="text-light" href="https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki">Schnelltestpartner
-        werden</a>
     <a class="text-light" target="_blank" href="https://www.coronawarn.app">Corona-Warn-App</a>
 </div>
 

--- a/static/impressum.html
+++ b/static/impressum.html
@@ -96,8 +96,6 @@
     <a class="text-light" href="/impressum.html">Impressum</a>
     <a class="text-light" href="/datenschutz.html">Datenschutzerklärung</a>
     <a class="text-light" href="/usage.html">Hilfe</a>
-    <a class="text-light" href="https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki">Schnelltestpartner
-        werden</a>
     <a class="text-light" target="_blank" href="https://www.coronawarn.app">Corona-Warn-App</a>
 </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -146,8 +146,6 @@
     <a class="text-light" href="/impressum.html">Impressum</a>
     <a class="text-light" href="/datenschutz.html">Datenschutzerklärung</a>
     <a class="text-light" href="/usage.html">Hilfe</a>
-    <a class="text-light" href="https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki">Schnelltestpartner
-        werden</a>
     <a class="text-light" target="_blank" href="https://www.coronawarn.app">Corona-Warn-App</a>
 </div>
 

--- a/static/usage.html
+++ b/static/usage.html
@@ -67,14 +67,6 @@
                 <p class="text-muted">Sollten Sie eine Teststelle gefunden haben, welche sich nicht auf der Karte
                     befindet, sprechen Sie gern den Betreiber darauf an. Nur dieser ist in der Lage, die Teststelle hier
                     listen zu lassen.</p>
-
-                <p class="text-muted"> Wollen Sie ebenfalls Schnelltestpartner für die Übermittlung der
-                    Testergebnisse in die
-                    Corona-Warn-App werden, dann folgen Sie dem Button:</p>
-                <div class="offset-lg-4">
-                    <a class="btn btn-dark btn-secondary bg-main" target="_blank"
-                       href="https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki">Schnelltestpartner
-                        werden</a>
                 </div>
                 </p>
             </div>
@@ -86,8 +78,6 @@
     <a class="text-light" href="/impressum.html">Impressum</a>
     <a class="text-light" href="/datenschutz.html">Datenschutzerklärung</a>
     <a class="text-light" href="/usage.html">Hilfe</a>
-    <a class="text-light" href="https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki">Schnelltestpartner
-        werden</a>
     <a class="text-light" target="_blank" href="https://www.coronawarn.app">Corona-Warn-App</a>
 </div>
 


### PR DESCRIPTION
## Description

This PR removes the link to the CWA onboarding wiki from the footer and also removes the button "Schnelltestpartner werden" from the usage site.

## What was changed

- The link to https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki was removed from the footer of all pages
- The link to https://github.com/corona-warn-app/cwa-quicktest-onboarding/wiki was removed from https://map.schnelltestportal.de/usage.html

## Screenshots

### Main page
![Bildschirmfoto 2022-05-06 um 17 33 18](https://user-images.githubusercontent.com/67682506/167165173-3396b572-82f6-4b59-ae68-9aad5bf77b1e.png)

### Usage page
![Bildschirmfoto 2022-05-06 um 17 33 23](https://user-images.githubusercontent.com/67682506/167165122-2ec7db4b-dc1d-41c7-bcdd-a02eead9f73f.png)

