### PR TITLE
Update subheading text (Addresses #20)

### DIFF
--- a/static/datenschutz.html
+++ b/static/datenschutz.html
@@ -42,8 +42,8 @@
         </a>
         <a href="/" title="Startseite">
             <div class="title text-light cwa-heading">Corona-Warn-App - Schnellteststellensuche</div>
-            <div class="title text-light cwa-subheading">Die hier gezeigten Schnelltestzentren werden täglich
-                aktualisiert
+            <div class="title text-light cwa-subheading">Für die Richtigkeit der Teststellendaten sind die Testanbieter
+                verantwortlich
             </div>
         </a>
     </div>

--- a/static/impressum.html
+++ b/static/impressum.html
@@ -35,8 +35,8 @@
         </a>
         <a href="/" title="Startseite">
             <div class="title text-light cwa-heading">Corona-Warn-App - Schnellteststellensuche</div>
-            <div class="title text-light cwa-subheading">Die hier gezeigten Schnelltestzentren werden täglich
-                aktualisiert
+            <div class="title text-light cwa-subheading">Für die Richtigkeit der Teststellendaten sind die Testanbieter
+                verantwortlich
             </div>
         </a>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -34,8 +34,8 @@
         </a>
         <a href="/" title="Startseite">
             <div class="title text-light cwa-heading">Corona-Warn-App - Schnellteststellensuche</div>
-            <div class="title text-light cwa-subheading">Die hier gezeigten Schnelltestzentren werden täglich
-                aktualisiert
+            <div class="title text-light cwa-subheading">Für die Richtigkeit der Teststellendaten sind die Testanbieter
+                verantwortlich
             </div>
         </a>
     </div>

--- a/static/usage.html
+++ b/static/usage.html
@@ -35,8 +35,8 @@
         </a>
         <a href="/" title="Startseite">
             <div class="title text-light cwa-heading">Corona-Warn-App - Schnellteststellensuche</div>
-            <div class="title text-light cwa-subheading">Die hier gezeigten Schnelltestzentren werden täglich
-                aktualisiert
+            <div class="title text-light cwa-subheading">DFür die Richtigkeit der Teststellendaten sind die Testanbieter
+                verantwortlich
             </div>
         </a>
     </div>


### PR DESCRIPTION
This PR changes the subheading text from "Die hier gezeigten Schnelltestzentren werden täglich aktualisiert" to "Für die Richtigkeit der Teststellendaten sind die Testanbieter verantwortlich."

---

**Closes #20**