### PR TITLE
Fix Impressum formatting

### DIFF
--- a/static/impressum.html
+++ b/static/impressum.html
@@ -52,7 +52,7 @@
     <span><strong>Adresse:</strong></span>
     <address>
         Hahnstraße 43d<br>
-        D-60528 Frankfurt am Main<br>
+        60528 Frankfurt am Main, Germany<br>
         E-Mail: info@t-systems.com<br>
         Telefon: 069 20060 - 0<br>
     </address>
@@ -68,7 +68,7 @@
     <span><strong>Aufsichtsbehörde:</strong></span>
     <address>
         Bundesnetzagentur für Elektrizität, Gas, Telekommunikation, Post und Eisenbahnen<br>
-        Tulpenfeld 4, 53113 Bonn<br>
+        Tulpenfeld 4, 53113 Bonn, Germany<br>
     </address>
 
 
@@ -87,8 +87,8 @@
     <address>
         T-Systems International GmbH<br>
         Christian R. Andersen<br>
-        Friedrich-Ebert-Allee-140<br>
-        D – 53113 Bonn<br>
+        Friedrich-Ebert-Allee 140<br>
+        53113 Bonn, Germany<br>
     </address>
 </div>
 


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-map-public-frontend/issues/23 "Address format errors in T-Systems International GmbH Impressum".

- Instances of "D-" / "D -" are removed and the country "Germany" is added to all addresses.
- The extra hyphen in front of the house number 140 in Friedrich-Ebert-Alle is removed.