### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag cwa-map-public-frontend:$(date +%s)


### PR DESCRIPTION
This PR fixes the deprecation warning

"[build](https://github.com/corona-warn-app/cwa-map-public-frontend/actions/runs/3375734268/jobs/5602658274)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout"

for example from https://github.com/corona-warn-app/cwa-map-public-frontend/actions/runs/3375734268

See https://github.com/actions/checkout/releases/tag/v3.0.0